### PR TITLE
Set max connections to 1

### DIFF
--- a/snowflake/provider.go
+++ b/snowflake/provider.go
@@ -48,6 +48,8 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
+	db.SetMaxIdleConns(1)
+	db.SetMaxOpenConns(1)
 	err = db.Ping()
 	// _, err = db.Exec("select 1")
 	if err != nil {


### PR DESCRIPTION
Limits the numbers of browser tabs opened when using externalbrowser authenticator to 1