### PR TITLE
update resource_snowflake_stage

### DIFF
--- a/snowflake/resource_snowflake_stage.go
+++ b/snowflake/resource_snowflake_stage.go
@@ -51,11 +51,27 @@ func resourceSnowflakeStage() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				StateFunc: func(v interface{}) string {
-					return strings.ToLower(v.(string))
+					return v.(string)
 				},
 				ForceNew: true,
 			},
 			"credentials": {
+				Type:      schema.TypeString,
+				Optional:  true,
+				ForceNew:  true,
+				Sensitive: true,
+			},
+			"file_format": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"copy_options": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"encryption": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
@@ -82,6 +98,9 @@ func resourceSnowflakeStageCreate(d *schema.ResourceData, meta interface{}) erro
 	stageId := fmt.Sprintf("%s.%s.%s", database, schema, name)
 	url := d.Get("url")
 	credentials := d.Get("credentials")
+	file_format := d.Get("file_format")
+	copy_options := d.Get("copy_options")
+	encryption := d.Get("encryption")
 
 	statement := fmt.Sprintf("CREATE STAGE %v.%v.%v", database, schema, name)
 	if url != "" {
@@ -90,7 +109,15 @@ func resourceSnowflakeStageCreate(d *schema.ResourceData, meta interface{}) erro
 	if credentials != "" {
 		statement += fmt.Sprintf(" CREDENTIALS = (%v)", credentials)
 	}
-
+	if file_format != "" {
+		statement += fmt.Sprintf(" file_format = (%v)", file_format)
+	}
+	if copy_options != "" {
+		statement += fmt.Sprintf(" copy_options = (%v)", copy_options)
+	}
+	if encryption != "" {
+		statement += fmt.Sprintf(" encryption = (%v)", encryption)
+	}
 	_, err := db.Exec(statement)
 	if err != nil {
 		return err


### PR DESCRIPTION
- new options for stage creation :
   - file_format
   - copy_options
   - encryption
- remove the `strings.ToLower` from stage url, url can be a s3 bucket/prefix, and objects in s3 are case sensitive 
- updated stage credentials schema to be `sensitive`, we don't want to display that on terraform (plan/apply)